### PR TITLE
bug fix - repeatmasker gtfs should have 9 not 10 fields

### DIFF
--- a/src/python/ensembl/tools/anno/repeat_annotation/repeatmasker.py
+++ b/src/python/ensembl/tools/anno/repeat_annotation/repeatmasker.py
@@ -263,7 +263,7 @@ def _create_repeatmasker_gtf(  # pylint: disable=too-many-locals
                     strand = "-"
                 gtf_line = (
                     f"{region_name}\tRepeatMasker\trepeat\t{start}\t{end}\t.\t"
-                    f"{strand}\t.\trepeat_id\t{repeat_count}; "
+                    f"{strand}\t.\trepeat_id {repeat_count}; "
                     f'repeat_name "{repeat_name}"; repeat_class "{repeat_class}"; '
                     f'repeat_type "{repeat_type}"; repeat_start "{repeat_start}"; '
                     f'repeat_end "{repeat_end}"; score "{score}";\n'


### PR DESCRIPTION
# PR details
_create_repeatmasker_gtf() incorrectly inserts a tab rather than a space between repeat_id and the repeat_count (which is used as a repeat id). Thus, _create_repeatmasker_gtf() generates sliced gtfs with 10 tab separated fields per line. Downstream in _utils.py, there is a function that combines the sliced gtfs into one gtf called slice_output_to_gtf(). slice_output_to_gtf() checks each line in the input sliced gtfs and skips lines that don't have exactly 9 fields - meaning all of the repeatmasker gtf lines are skipped and an empty final gtf is always generated for repeat masker. Replacing the incorrect tab with a space as shown below fixes the issue.

https://embl.atlassian.net/browse/ENSGENEBUI-3989

